### PR TITLE
fix(mongodb): 合并进数组的操作，当更新的数据所存在的文档中，没有该数组字段，则会更新失败

### DIFF
--- a/connectors/mongodb-connector/pom.xml
+++ b/connectors/mongodb-connector/pom.xml
@@ -82,6 +82,31 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Mockito -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/error/BulkWriteErrorCodeHandlerEnum.java
+++ b/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/error/BulkWriteErrorCodeHandlerEnum.java
@@ -2,6 +2,7 @@ package io.tapdata.mongodb.writer.error;
 
 import io.tapdata.mongodb.writer.error.handler.Code11000Handler;
 import io.tapdata.mongodb.writer.error.handler.Code28Handler;
+import io.tapdata.mongodb.writer.error.handler.Code2Handler;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -14,6 +15,7 @@ import java.util.Map;
 public enum BulkWriteErrorCodeHandlerEnum {
 	CODE_28(28, new Code28Handler()),
 	CODE_11000(11000, new Code11000Handler()),
+	CODE_2(2, new Code2Handler()),
 	;
 	private final int code;
 	private final BulkWriteErrorHandler bulkWriteErrorHandler;

--- a/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/error/handler/Code28Handler.java
+++ b/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/error/handler/Code28Handler.java
@@ -1,7 +1,6 @@
 package io.tapdata.mongodb.writer.error.handler;
 
 import com.mongodb.MongoBulkWriteException;
-import com.mongodb.WriteError;
 import com.mongodb.bulk.BulkWriteError;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.BulkWriteOptions;
@@ -17,7 +16,6 @@ import org.bson.Document;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -54,7 +52,7 @@ public class Code28Handler implements BulkWriteErrorHandler {
 			return null;
 		}
 		Map<String, Object> set = (Map) update.get("$set");
-		String errorField = getErrorField(writeError);
+		String errorField = getErrorField(writeError, PATTERN, 2);
 
 		if (MapUtils.isEmpty(set) || StringUtils.isBlank(errorField)) {
 			return null;
@@ -89,17 +87,5 @@ public class Code28Handler implements BulkWriteErrorHandler {
 			return null;
 		}
 		return writeModel;
-	}
-
-	private String getErrorField(WriteError writeError) {
-		if (null == writeError || StringUtils.isBlank(writeError.getMessage())) {
-			return null;
-		}
-		Matcher matcher = PATTERN.matcher(writeError.getMessage());
-		if (matcher.find() && matcher.groupCount() >= 1) {
-			return matcher.group(2);
-		} else {
-			return null;
-		}
 	}
 }

--- a/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/error/handler/Code2Handler.java
+++ b/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/error/handler/Code2Handler.java
@@ -1,0 +1,82 @@
+package io.tapdata.mongodb.writer.error.handler;
+
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.bulk.BulkWriteError;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.BulkWriteOptions;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import io.tapdata.mongodb.writer.BulkWriteModel;
+import io.tapdata.mongodb.writer.error.BulkWriteErrorHandler;
+import org.apache.commons.lang3.StringUtils;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * @author samuel
+ * @Description Use array filter option to update an element in array, when array field not exists, will occur this error.
+ * e.g. Execute the following command in mongo shell will reproduce this error
+ * 1. db.test.insert({id: 1})
+ * 2. db.test.updateOne({id: 1},{$set: {'arr.$[elem1].fld1': 1,'arr.$[elem1].fld2': 'test'}},{arrayFilters: [{'elem1.fld1': 1}]})
+ * Error message: The path 'arr' must exist in the document in order to apply array updates
+ * @create 2023-12-08 16:24
+ **/
+public class Code2Handler implements BulkWriteErrorHandler {
+
+	public static final Pattern PATTERN = Pattern.compile("The path '(.*?)' must exist in the document in order to apply array updates\\.");
+	public static final String $_ELEMENT_1 = "$[element1]";
+
+	@Override
+	public WriteModel<Document> handle(BulkWriteModel bulkWriteModel, WriteModel<Document> writeModel, BulkWriteOptions bulkWriteOptions, MongoBulkWriteException mongoBulkWriteException, BulkWriteError writeError, MongoCollection<Document> collection) {
+		String errorField = getErrorField(writeError, PATTERN, 1);
+		if (StringUtils.isBlank(errorField)) {
+			return null;
+		}
+		UpdateOptions updateOptions = updateOptions(writeModel);
+		List<? extends Bson> arrayFilters = updateOptions.getArrayFilters();
+		if (null == arrayFilters || arrayFilters.isEmpty()) {
+			return null;
+		}
+		Document filter = updateModelFilter(writeModel);
+		if (null == filter) {
+			return null;
+		}
+		Document update = updateModelUpdate(writeModel);
+		if (!(update.get("$set") instanceof Document)) {
+			return null;
+		}
+		Document setDoc = (Document) update.get("$set");
+		if (null == setDoc || setDoc.isEmpty()) {
+			return null;
+		}
+		Document newSetDoc = new Document();
+		Document addToSetDoc = new Document();
+		for (Map.Entry<String, Object> entry : setDoc.entrySet()) {
+			String key = entry.getKey();
+			Object value = entry.getValue();
+			if (key.contains($_ELEMENT_1)) {
+				int index = key.indexOf($_ELEMENT_1);
+				addToSetDoc.append(key.substring(index + $_ELEMENT_1.length() + 1), value);
+			} else {
+				newSetDoc.append(key, value);
+			}
+		}
+		if (newSetDoc.isEmpty() && addToSetDoc.isEmpty()) {
+			return null;
+		}
+		update.clear();
+		if (!newSetDoc.isEmpty()) {
+			update.append("$set", newSetDoc);
+		}
+		if (!addToSetDoc.isEmpty()) {
+			update.append("$addToSet", new Document(errorField, addToSetDoc));
+		}
+		updateOptions.arrayFilters(null);
+
+		return writeModel;
+	}
+}

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -75,6 +75,8 @@
 		<maven.compiler.encoding>UTF-8</maven.compiler.encoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<pdk-error-code.version>1.0-SNAPSHOT</pdk-error-code.version>
+		<mockito.version>4.11.0</mockito.version>
+		<byte-buddy.version>1.12.23</byte-buddy.version>
 	</properties>
 
 	<dependencies>
@@ -171,6 +173,36 @@
 				<artifactId>pdk-error-code</artifactId>
 				<version>${pdk-error-code.version}</version>
 				<scope>provided</scope>
+			</dependency>
+
+			<!-- Mockito -->
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-core</artifactId>
+				<version>${mockito.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-junit-jupiter</artifactId>
+				<version>${mockito.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-inline</artifactId>
+				<version>${mockito.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>net.bytebuddy</groupId>
+				<artifactId>byte-buddy</artifactId>
+				<version>${byte-buddy.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>net.bytebuddy</groupId>
+				<artifactId>byte-buddy-agent</artifactId>
+				<version>${byte-buddy.version}</version>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
异常信息: "The path 'employee' must exist in the document in order to apply array updates."，添加错误处理，遇到该报错时，将array filters的更新方式改为addToSet