### PR TITLE
fix(mongodb): Some aggregate pipelines are not supported because null values are incorrectly filtered

### DIFF
--- a/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/ExecuteObject.java
+++ b/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/ExecuteObject.java
@@ -1,6 +1,7 @@
 package io.tapdata.mongodb;
 
 import io.tapdata.entity.simplify.TapSimplify;
+import io.tapdata.entity.utils.JsonParser;
 import io.tapdata.pdk.apis.exception.NotSupportedException;
 import org.bson.Document;
 
@@ -79,13 +80,13 @@ public class ExecuteObject {
 			List<Document> pipeline = new ArrayList<>();
 			if (obj instanceof List) {
 				for (Map<String, Object> o : (List<Map<String, Object>>) obj) {
-					pipeline.add(Document.parse(TapSimplify.toJson(o)));
+					pipeline.add(Document.parse(TapSimplify.toJson(o, JsonParser.ToJsonFeature.WriteMapNullValue)));
 				}
 				return pipeline;
 			} else if (obj instanceof String) {
 				List<?> list = TapSimplify.fromJson((String) obj, List.class);
 				for (Object o : list) {
-					pipeline.add(Document.parse(TapSimplify.toJson(o)));
+					pipeline.add(Document.parse(TapSimplify.toJson(o, JsonParser.ToJsonFeature.WriteMapNullValue)));
 				}
 				return pipeline;
 			} else {

--- a/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/MongodbConnector.java
+++ b/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/MongodbConnector.java
@@ -780,6 +780,7 @@ public class MongodbConnector extends ConnectorBase {
 		try {
 			Map<String, Object> executeObj = tapExecuteCommand.getParams();
 			String command = tapExecuteCommand.getCommand();
+			tapConnectorContext.getLog();
 			if (MapUtils.isNotEmpty(executeObj) && StringUtils.isEmpty((CharSequence) executeObj.get("database"))) {
 				executeObj.put("database", mongoConfig.getDatabase());
 			}
@@ -1142,6 +1143,7 @@ public class MongodbConnector extends ConnectorBase {
 			}
 		}
 		exceptionCollector = new MongodbExceptionCollector();
+		mongodbExecuteCommandFunction.setLog(connectionContext.getLog());
 	}
 
 	private void dropTable(TapConnectorContext connectorContext, TapDropTableEvent dropTableEvent) throws Throwable {


### PR DESCRIPTION
sample
- input: [{"$match": {"xxx": {"$ne": null}}}]
- actual excute: [{"$match": {"xxx": {}}}] will not return the right data that user want