### PR TITLE
TAP-3414 fix(mongodb): Incremental data INCENTIVE_APP_CP_INVNT_PURCHS_LINE is …

### DIFF
--- a/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/MongodbMergeOperate.java
+++ b/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/MongodbMergeOperate.java
@@ -573,30 +573,30 @@ public class MongodbMergeOperate {
 		Map<String, Object> removefields = mergeBundle.getRemovefields();
 		MergeBundle.EventOperation operation = mergeBundle.getOperation();
 		List<String> arrayKeys = currentProperty.getArrayKeys();
+		Map<String, Object> filterMap = buildFilterMap(operation, after, before);
 		if (array) {
 			List<Document> arrayFilter;
 			if (operation == MergeBundle.EventOperation.UPDATE) {
 				arrayFilter = arrayFilter(
-						MapUtils.isNotEmpty(mergeBundle.getBefore()) ? mergeBundle.getBefore() : mergeBundle.getAfter(),
+						filterMap,
 						currentProperty.getJoinKeys(),
 						arrayKeys,
 						currentProperty.getArrayPath()
 				);
 			} else {
 				arrayFilter = arrayFilter(
-						MapUtils.isNotEmpty(mergeBundle.getBefore()) ? mergeBundle.getBefore() : mergeBundle.getAfter(),
+						filterMap,
 						currentProperty.getJoinKeys(),
 						currentProperty.getArrayPath());
 			}
 			mergeResult.getUpdateOptions().arrayFilters(arrayFilter);
 		} else {
-			Map<String, Object> filterMap = buildFilterMap(operation, after, before);
 			Document filter = filter(filterMap, currentProperty.getJoinKeys());
 			mergeResult.getFilter().putAll(filter);
 
 			if (operation == MergeBundle.EventOperation.UPDATE) {
 				List<Document> arrayFilter = arrayFilterForArrayMerge(
-						MapUtils.isNotEmpty(mergeBundle.getBefore()) ? mergeBundle.getBefore() : mergeBundle.getAfter(),
+						filterMap,
 						currentProperty.getArrayKeys(),
 						currentProperty.getTargetPath(),
 						currentProperty.getArrayPath()


### PR DESCRIPTION
…missing invntIndex.catalogItem

Update events, merge arrays, and build arrayFilters from before first. If there is a js node in the middle to change the field name, the data in before will not be renamed. As a result, arrayFilters cannot correctly obtain the field value, and instead takes the value from after first.

Closes TAP-3414