### PR TITLE
fix: TAP-4264 modify custom String type default value to 500 to resol…

### DIFF
--- a/connectors-common/connector-core/src/main/java/io/tapdata/base/ConnectorBase.java
+++ b/connectors-common/connector-core/src/main/java/io/tapdata/base/ConnectorBase.java
@@ -181,7 +181,7 @@ public abstract class ConnectorBase implements TapConnector {
     }
 
     public static TestItem testItem(String item, int resultCode) {
-        return new TestItem(item, resultCode);
+        return new TestItem(item, resultCode, null);
     }
 
     public static TestItem testItem(String item, int resultCode, String information) {

--- a/connectors/bigquery-connector/src/main/resources/spec-v2.json
+++ b/connectors/bigquery-connector/src/main/resources/spec-v2.json
@@ -120,14 +120,14 @@
     "BYTES[($bit)]": {
       "name": "BYTES",
       "to": "TapBinary",
-      "byte": 9223372036854775807,
-      "defaultByte": 9223372036854775807
+      "byte": 2147483648,
+      "defaultByte": 2147483648
     },
     "STRING[($byte)]": {
       "name": "STRING",
       "to": "TapString",
-      "byte": 9223372036854775807,
-      "defaultByte": 9223372036854775807
+      "byte": 2147483648,
+      "defaultByte": 2147483647
     },
     "INT64": {
       "to": "TapNumber",

--- a/connectors/custom-connector/src/main/resources/spec_custom.json
+++ b/connectors/custom-connector/src/main/resources/spec_custom.json
@@ -426,8 +426,8 @@
     "String": {
       "byte": 200,
       "priority": 1,
-      "defaultByte": 200,
-      "preferByte": 200,
+      "defaultByte": 500,
+      "preferByte": 500,
       "to": "TapString"
     },
     "Text": {


### PR DESCRIPTION
…ve custom fields length exceed 200, and bigquery String type default value to 2147483648 to resolve modify fields occur parseLong error