### PR TITLE
fix: conversion of data types to uppercase causes enum and set type value errors.

### DIFF
--- a/connectors-common/mysql-core/src/main/java/io/tapdata/connector/mysql/MysqlMaker.java
+++ b/connectors-common/mysql-core/src/main/java/io/tapdata/connector/mysql/MysqlMaker.java
@@ -280,8 +280,8 @@ public class MysqlMaker implements SqlMaker {
     }
 
     protected String createTableAppendField(TapField tapField) {
-        String datatype = tapField.getDataType().toUpperCase();
-        String fieldSql = "  `" + tapField.getName() + "`" + " " + tapField.getDataType().toUpperCase();
+        String datatype = tapField.getDataType();
+        String fieldSql = "  `" + tapField.getName() + "`" + " " + datatype;
 
         // auto increment
         // mysql a table can only create one auto-increment column, and must be the primary key


### PR DESCRIPTION
The migration of MySQL table structures, where data types were uniformly converted to uppercase, inconsistencies may arise in the migration table structure and data, particularly affecting SET and ENUM types.

This is details:
* migration table structure 
![image](https://github.com/user-attachments/assets/bca8f452-eef4-4ca7-9d46-1fc2d62e9857)
* migration table raw data
![image](https://github.com/user-attachments/assets/2b664f8f-2e17-4e92-a26f-05a3bc0408db)
