### PR TITLE
fix(mongodb): TAP-5053 After the associated key change is enabled, th…

### DIFF
--- a/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/MongodbMergeOperate.java
+++ b/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/MongodbMergeOperate.java
@@ -252,11 +252,12 @@ public class MongodbMergeOperate {
 		if (null == mergeResult) {
 			firstMergeResult = true;
 			MergeInfo.UpdateJoinKey updateJoinKey = updateJoinKeys.get(id);
+			Map<String, Object> updateJoinKeyAfter = updateJoinKey.getAfter();
 			Map<String, Object> updateJoinKeyBefore = updateJoinKey.getBefore();
 			List<Map<String, String>> joinKeys = currentProperty.getJoinKeys();
 			Document filter;
 			mergeResult = new MergeResult();
-			filter = unsetFilter(updateJoinKeyBefore, joinKeys);
+			filter = unsetFilter(updateJoinKeyBefore, updateJoinKeyAfter, joinKeys, sharedJoinKeys);
 			if (null != updateJoinKey.getParentBefore()) {
 				filter.putAll(updateJoinKey.getParentBefore());
 			}
@@ -810,10 +811,17 @@ public class MongodbMergeOperate {
 		return document;
 	}
 
-	protected static Document unsetFilter(Map<String, Object> data, List<Map<String, String>> joinKeys) {
+	protected static Document unsetFilter(Map<String, Object> before, Map<String, Object> after, List<Map<String, String>> joinKeys, Set<String> sharedJoinKeys) {
 		Document document = new Document();
 		for (Map<String, String> joinKey : joinKeys) {
-			document.put(joinKey.get("target"), MapUtil.getValueByKey(data, joinKey.get("target")));
+			String key = joinKey.get("target");
+			Object value;
+			if (sharedJoinKeys.contains(key)) {
+				value = MapUtil.getValueByKey(after, key);
+			} else {
+				value = MapUtil.getValueByKey(before, key);
+			}
+			document.put(key, value);
 		}
 		return document;
 	}

--- a/connectors/mongodb-connector/src/test/java/io/tapdata/mongodb/writer/MongodbMergeOperateTest.java
+++ b/connectors/mongodb-connector/src/test/java/io/tapdata/mongodb/writer/MongodbMergeOperateTest.java
@@ -484,15 +484,21 @@ class MongodbMergeOperateTest {
 	@DisplayName("Method unsetFilter test")
 	class unsetFilterTest {
 
-		private Document data;
+		private Document before;
+		private Document after;
 		private List<Map<String, String>> joinKeys;
+		private Set<String> shareJoinKeys;
 
 		@BeforeEach
 		void setUp() {
-			data = new Document("id1", 1)
+			before = new Document("id1", 1)
 					.append("type1", "xxx")
 					.append("f1", "zzzz")
 					.append("f2", 625.85);
+			after = new Document("id1", 2)
+					.append("type1", "zzz")
+					.append("f1", "yyyy")
+					.append("f2", 123.45);
 			joinKeys = new ArrayList<>();
 			joinKeys.add(new HashMap<String, String>() {{
 				put("source", "id");
@@ -502,13 +508,15 @@ class MongodbMergeOperateTest {
 				put("source", "type");
 				put("target", "type1");
 			}});
+			shareJoinKeys = new HashSet<>();
+			shareJoinKeys.add("id1");
 		}
 
 		@Test
 		@DisplayName("test main process")
 		void test1() {
-			Document filter = MongodbMergeOperate.unsetFilter(data, joinKeys);
-			assertEquals(new Document("id1", 1).append("type1", "xxx"), filter);
+			Document filter = MongodbMergeOperate.unsetFilter(before, after, joinKeys, shareJoinKeys);
+			assertEquals(new Document("id1", 2).append("type1", "xxx"), filter);
 		}
 	}
 }


### PR DESCRIPTION
…e related attributes of the child table cannot be deleted after the associated key is changed.

Closes TAP-5053