### PR TITLE
fix: 优化mongodb写入

### DIFF
--- a/connectors/mongodb-connector/pom.xml
+++ b/connectors/mongodb-connector/pom.xml
@@ -12,7 +12,7 @@
     <name>mongodb-connector</name>
 
     <properties>
-        <java.version>8</java.version>
+        <java.version>11</java.version>
         <tapdata.pdk.api.version>1.4.4-SNAPSHOT</tapdata.pdk.api.version>
     </properties>
     <dependencies>

--- a/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/util/MapDiffUtil.java
+++ b/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/util/MapDiffUtil.java
@@ -1,0 +1,365 @@
+package io.tapdata.mongodb.util;
+
+import java.util.*;
+
+/**
+ * Map comparison utility class
+ * Used to compare two Maps, find keys that exist in 'before' but not in 'after', and record detailed path information
+ */
+public class MapDiffUtil {
+
+    /**
+     * Compare two Maps and return information about keys that exist in 'before' but not in 'after'
+     *
+     * Functionality Description:
+     * 1. Compares two Maps to find keys that exist in 'before' but not in 'after'
+     * 2. Supports recursive comparison of nested Map structures
+     * 3. Special limitations for List type handling:
+     *    - In the main comparison flow (compareMapRecursively method), List type comparison is completely ignored
+     *    - Only when the 'before' value is a Map and the 'after' value is not a Map, all keys in 'before' will be recorded
+     *    - Structural changes within Lists are not detected or recorded
+     *
+     * List Limitation Boundaries:
+     * - Does not support comparison of List element additions/deletions
+     * - Does not support detection of element order changes within Lists
+     * - Does not support deep comparison of nested Map/List structures within Lists
+     * - When a Map field changes from List type to other types, differences will not be recorded
+     * - When a Map field changes from other types to List type, differences will not be recorded
+     *
+     * Applicable Scenarios:
+     * - Primarily used for detecting missing keys in Map structures
+     * - Suitable for document structure change detection, but not for array content change detection
+     * - Recommended for schema change detection, not for data content change detection
+     *
+     * @param before Original Map, cannot be null
+     * @param after  Target Map, can be null (will be treated as empty Map)
+     * @return List of key difference information containing detailed path information of missing keys.
+     *         Returns empty list if 'before' is empty
+     */
+    public static List<KeyDiffInfo> compareAndFindMissingKeys(Map<String, Object> before, Map<String, Object> after) {
+        List<KeyDiffInfo> result = new ArrayList<>();
+
+        if (isEmpty(before)) {
+            return result;
+        }
+
+        if (isEmpty(after)) {
+            after = new HashMap<>();
+        }
+        
+        compareMapRecursively(before, after, "", new ArrayList<>(), result);
+        
+        return result;
+    }
+
+    /**
+     * Check if Map is empty
+     *
+     * @param map Map to check
+     * @return true if Map is null or empty
+     */
+    private static boolean isEmpty(Map<String, Object> map) {
+        return map == null || map.isEmpty();
+    }
+
+    /**
+     * Check if string is null or blank
+     *
+     * @param str String to check
+     * @return true if string is null, empty, or contains only whitespace characters
+     */
+    private static boolean isBlank(String str) {
+        return str == null || str.trim().isEmpty();
+    }
+
+    /**
+     * Recursively compare Maps (ignore array paths, only compare nested structures of Map type)
+     *
+     * @param beforeMap    Original Map
+     * @param afterMap     Target Map
+     * @param currentPath  Current path
+     * @param pathTypes    List of path types
+     * @param result       Result list
+     */
+    private static void compareMapRecursively(Map<String, Object> beforeMap,
+                                            Map<String, Object> afterMap,
+                                            String currentPath,
+                                            List<PathType> pathTypes,
+                                            List<KeyDiffInfo> result) {
+
+        for (Map.Entry<String, Object> entry : beforeMap.entrySet()) {
+            String key = entry.getKey();
+            Object beforeValue = entry.getValue();
+
+            // Build current full path
+            String fullPath = isBlank(currentPath) ? key : currentPath + "." + key;
+
+            // Check if the key exists in after
+            if (!afterMap.containsKey(key)) {
+                // Key does not exist in after, record difference (without path types)
+                KeyDiffInfo diffInfo = new KeyDiffInfo(key, fullPath, null);
+                result.add(diffInfo);
+            } else {
+                // Key exists in after, continue recursive comparison
+                Object afterValue = afterMap.get(key);
+                // Only continue recursive comparison when both values are Maps, ignore array types
+                if (beforeValue instanceof Map && afterValue instanceof Map) {
+                    compareMapRecursively((Map<String, Object>) beforeValue,
+                                        (Map<String, Object>) afterValue,
+                                        fullPath,
+                                        pathTypes,
+                                        result);
+                } else if (beforeValue instanceof Map && !(afterValue instanceof Map)) {
+                    // before is Map but after is not Map, record all keys in before (only handle Map type)
+                    recordAllKeysInMapOnly((Map<String, Object>) beforeValue, fullPath, result);
+                }
+                // Ignore List type comparison
+            }
+        }
+    }
+
+    /**
+     * Recursively compare values
+     *
+     * @param beforeValue     Original value
+     * @param afterValue      Target value
+     * @param currentPath     Current path
+     * @param pathTypes       List of path types
+     * @param result          Result list
+     */
+    @SuppressWarnings("unchecked")
+    private static void compareValueRecursively(Object beforeValue, 
+                                              Object afterValue, 
+                                              String currentPath, 
+                                              List<PathType> pathTypes, 
+                                              List<KeyDiffInfo> result) {
+        
+        if (beforeValue instanceof Map && afterValue instanceof Map) {
+            // Both are Maps, recursively compare
+            compareMapRecursively((Map<String, Object>) beforeValue,
+                                (Map<String, Object>) afterValue,
+                                currentPath,
+                                pathTypes,
+                                result);
+        } else if (beforeValue instanceof List && afterValue instanceof List) {
+            // Both are Lists, compare elements in List
+            compareListRecursively((List<Object>) beforeValue,
+                                 (List<Object>) afterValue,
+                                 currentPath,
+                                 pathTypes,
+                                 result);
+        } else if (beforeValue instanceof Map && !(afterValue instanceof Map)) {
+            // before is Map but after is not Map, record all keys in before
+            recordAllKeysInMap((Map<String, Object>) beforeValue, currentPath, pathTypes, result);
+        } else if (beforeValue instanceof List && !(afterValue instanceof List)) {
+            // before is List but after is not List, record all elements in before
+            recordAllKeysInList((List<Object>) beforeValue, currentPath, pathTypes, result);
+        }
+        // Other cases (primitive type comparison) do not need to be handled, as we only care about structural differences
+    }
+
+    /**
+     * Recursively compare Lists
+     *
+     * @param beforeList   Original List
+     * @param afterList    Target List
+     * @param currentPath  Current path
+     * @param pathTypes    List of path types
+     * @param result       Result list
+     */
+    @SuppressWarnings("unchecked")
+    private static void compareListRecursively(List<Object> beforeList, 
+                                             List<Object> afterList, 
+                                             String currentPath, 
+                                             List<PathType> pathTypes, 
+                                             List<KeyDiffInfo> result) {
+        
+        // Copy path type list and add current level type
+        List<PathType> currentPathTypes = new ArrayList<>(pathTypes);
+        currentPathTypes.add(PathType.LIST);
+
+        for (int i = 0; i < beforeList.size(); i++) {
+            Object beforeItem = beforeList.get(i);
+            String indexPath = currentPath + "[" + i + "]";
+
+            if (i >= afterList.size()) {
+                // No corresponding index element in after
+                if (beforeItem instanceof Map) {
+                    recordAllKeysInMap((Map<String, Object>) beforeItem, indexPath, currentPathTypes, result);
+                } else if (beforeItem instanceof List) {
+                    recordAllKeysInList((List<Object>) beforeItem, indexPath, currentPathTypes, result);
+                }
+            } else {
+                // Corresponding index element exists in after, continue comparison
+                Object afterItem = afterList.get(i);
+                compareValueRecursively(beforeItem, afterItem, indexPath, currentPathTypes, result);
+            }
+        }
+    }
+
+    /**
+     * Record all keys in Map (only handle Map type, ignore arrays)
+     *
+     * @param map          Map object
+     * @param currentPath  Current path
+     * @param result       Result list
+     */
+    @SuppressWarnings("unchecked")
+    private static void recordAllKeysInMapOnly(Map<String, Object> map,
+                                             String currentPath,
+                                             List<KeyDiffInfo> result) {
+
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            String fullPath = currentPath + "." + key;
+
+            // Record difference (without path types)
+            KeyDiffInfo diffInfo = new KeyDiffInfo(key, fullPath, null);
+            result.add(diffInfo);
+
+            // Only recursively handle nested structures of Map type, ignore List type
+            if (value instanceof Map) {
+                recordAllKeysInMapOnly((Map<String, Object>) value, fullPath, result);
+            }
+            // Ignore List type processing
+        }
+    }
+
+    /**
+     * Record all keys in Map
+     *
+     * @param map          Map object
+     * @param currentPath  Current path
+     * @param pathTypes    List of path types
+     * @param result       Result list
+     */
+    @SuppressWarnings("unchecked")
+    private static void recordAllKeysInMap(Map<String, Object> map,
+                                         String currentPath,
+                                         List<PathType> pathTypes,
+                                         List<KeyDiffInfo> result) {
+
+        List<PathType> currentPathTypes = new ArrayList<>(pathTypes);
+        currentPathTypes.add(PathType.MAP);
+
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            String fullPath = currentPath + "." + key;
+
+            KeyDiffInfo diffInfo = new KeyDiffInfo(key, fullPath, new ArrayList<>(currentPathTypes));
+            result.add(diffInfo);
+
+            // Recursively handle nested structures
+            if (value instanceof Map) {
+                recordAllKeysInMap((Map<String, Object>) value, fullPath, currentPathTypes, result);
+            } else if (value instanceof List) {
+                recordAllKeysInList((List<Object>) value, fullPath, currentPathTypes, result);
+            }
+        }
+    }
+
+    /**
+     * Record all elements in List
+     *
+     * @param list         List object
+     * @param currentPath  Current path
+     * @param pathTypes    List of path types
+     * @param result       Result list
+     */
+    @SuppressWarnings("unchecked")
+    private static void recordAllKeysInList(List<Object> list, 
+                                          String currentPath, 
+                                          List<PathType> pathTypes, 
+                                          List<KeyDiffInfo> result) {
+        
+        List<PathType> currentPathTypes = new ArrayList<>(pathTypes);
+        currentPathTypes.add(PathType.LIST);
+        
+        for (int i = 0; i < list.size(); i++) {
+            Object item = list.get(i);
+            String indexPath = currentPath + "[" + i + "]";
+            
+            if (item instanceof Map) {
+                recordAllKeysInMap((Map<String, Object>) item, indexPath, currentPathTypes, result);
+            } else if (item instanceof List) {
+                recordAllKeysInList((List<Object>) item, indexPath, currentPathTypes, result);
+            }
+        }
+    }
+
+    /**
+     * Path type enumeration
+     */
+    public enum PathType {
+        MAP("map"),
+        LIST("list");
+        
+        private final String type;
+        
+        PathType(String type) {
+            this.type = type;
+        }
+        
+        public String getType() {
+            return type;
+        }
+        
+        @Override
+        public String toString() {
+            return type;
+        }
+    }
+
+    /**
+     * Key difference information class
+     */
+    public static class KeyDiffInfo {
+        private final String key;
+        private final String fullPath;
+        private final List<PathType> pathTypes;
+        
+        public KeyDiffInfo(String key, String fullPath, List<PathType> pathTypes) {
+            this.key = key;
+            this.fullPath = fullPath;
+            this.pathTypes = pathTypes;
+        }
+        
+        public String getKey() {
+            return key;
+        }
+        
+        public String getFullPath() {
+            return fullPath;
+        }
+        
+        public List<PathType> getPathTypes() {
+            return pathTypes;
+        }
+        
+        @Override
+        public String toString() {
+            return "KeyDiffInfo{" +
+                    "key='" + key + '\'' +
+                    ", fullPath='" + fullPath + '\'' +
+                    ", pathTypes=" + pathTypes +
+                    '}';
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            KeyDiffInfo that = (KeyDiffInfo) o;
+            return Objects.equals(key, that.key) &&
+                    Objects.equals(fullPath, that.fullPath) &&
+                    Objects.equals(pathTypes, that.pathTypes);
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, fullPath, pathTypes);
+        }
+    }
+}

--- a/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/MongodbMergeOperate.java
+++ b/connectors/mongodb-connector/src/main/java/io/tapdata/mongodb/writer/MongodbMergeOperate.java
@@ -1,9 +1,6 @@
 package io.tapdata.mongodb.writer;
 
-import com.mongodb.client.model.DeleteOneModel;
-import com.mongodb.client.model.InsertOneModel;
-import com.mongodb.client.model.UpdateManyModel;
-import com.mongodb.client.model.WriteModel;
+import com.mongodb.client.model.*;
 import io.tapdata.entity.event.dml.TapDeleteRecordEvent;
 import io.tapdata.entity.event.dml.TapInsertRecordEvent;
 import io.tapdata.entity.event.dml.TapRecordEvent;
@@ -13,6 +10,7 @@ import io.tapdata.mongodb.entity.MergeBundle;
 import io.tapdata.mongodb.entity.MergeFilter;
 import io.tapdata.mongodb.entity.MergeResult;
 import io.tapdata.mongodb.merge.MergeFilterManager;
+import io.tapdata.mongodb.util.MapDiffUtil;
 import io.tapdata.mongodb.util.MapUtil;
 import io.tapdata.pdk.apis.entity.merge.MergeInfo;
 import io.tapdata.pdk.apis.entity.merge.MergeLookupResult;
@@ -39,9 +37,15 @@ public class MongodbMergeOperate {
 			writeModels = new ArrayList<>();
 			final MergeBundle mergeBundle = mergeBundle(tapRecordEvent);
 			final Map<String, Object> info = tapRecordEvent.getInfo();
+			List<MapDiffUtil.KeyDiffInfo> updateKeyDiffInfos = null;
 			if (tapRecordEvent instanceof TapInsertRecordEvent) {
 				inserted.incrementAndGet();
 			} else if (tapRecordEvent instanceof TapUpdateRecordEvent) {
+				if (MapUtils.isNotEmpty(((TapUpdateRecordEvent) tapRecordEvent).getBefore())
+						&& MapUtils.isNotEmpty(((TapUpdateRecordEvent) tapRecordEvent).getAfter())) {
+					updateKeyDiffInfos = MapDiffUtil.compareAndFindMissingKeys(((TapUpdateRecordEvent) tapRecordEvent).getBefore(),
+							((TapUpdateRecordEvent) tapRecordEvent).getAfter());
+				}
 				updated.incrementAndGet();
 			} else if (tapRecordEvent instanceof TapDeleteRecordEvent) {
 				deleted.incrementAndGet();
@@ -68,7 +72,8 @@ public class MongodbMergeOperate {
 						updateJoinKeys,
 						sharedJoinKeys,
 						mergeFilter,
-						level
+						level,
+						updateKeyDiffInfos
 				);
 
 				if (CollectionUtils.isNotEmpty(mergeResults)) {
@@ -102,7 +107,8 @@ public class MongodbMergeOperate {
 			Map<String, MergeInfo.UpdateJoinKey> updateJoinKeys,
 			Set<String> sharedJoinKeys,
 			MergeFilter mergeFilter,
-			int topLevel
+			int topLevel,
+			List<MapDiffUtil.KeyDiffInfo> updateKeyDiffInfos
 	) {
 		recursiveMerge(
 				mergeBundle,
@@ -116,7 +122,8 @@ public class MongodbMergeOperate {
 				null,
 				mergeFilter,
 				topLevel,
-				1
+				1,
+				updateKeyDiffInfos
 		);
 	}
 
@@ -132,9 +139,11 @@ public class MongodbMergeOperate {
 			MergeTableProperties parentProperties,
 			MergeFilter mergeFilter,
 			int topLevel,
-			int loopTime
+			int loopTime,
+			List<MapDiffUtil.KeyDiffInfo> updateKeyDiffInfos
 	) {
 		boolean unsetResultNull = null == unsetResult;
+		MergeResult updateKeyDiff = null;
 		switch (properties.getMergeType()) {
 			case updateOrInsert:
 				upsertMerge(mergeBundle, properties, mergeResult);
@@ -149,6 +158,7 @@ public class MongodbMergeOperate {
 				}
 				mergeResult = addMergeResults(mergeResults, mergeResult);
 				mergeResult = updateMergeIfNeed(mergeBundle, properties, mergeResult, sharedJoinKeys, mergeFilter);
+				updateKeyDiff = keyDiffUnsetWhenUpdateWrite(mergeResult, updateKeyDiffInfos);
 				break;
 			case updateIntoArray:
 				unsetResult = updateIntoArrayUnsetMerge(mergeBundle, properties, updateJoinKeys, unsetResult, parentProperties, mergeFilter, loopTime);
@@ -186,19 +196,33 @@ public class MongodbMergeOperate {
 						properties,
 						mergeFilter,
 						topLevel,
-						privateLoopTime
+						privateLoopTime,
+						null
 				);
 				recursiveOnce = true;
 			}
 			return;
 		}
 
-		if (mergeResult != null) {
-			mergeResults.add(mergeResult);
-		}
+		Optional.ofNullable(mergeResult).ifPresent(mergeResults::add);
+		Optional.ofNullable(updateKeyDiff).ifPresent(mergeResults::add);
 		if (mergeFilter.isAppend()) {
 			mergeFilter.removeLast();
 		}
+	}
+
+	private static MergeResult keyDiffUnsetWhenUpdateWrite(MergeResult mergeResult, List<MapDiffUtil.KeyDiffInfo> updateKeyDiffInfos) {
+		if (CollectionUtils.isNotEmpty(updateKeyDiffInfos)) {
+			Document unset = new Document();
+			updateKeyDiffInfos.forEach(updateKeyDiffInfo -> unset.append(updateKeyDiffInfo.getFullPath(), 1));
+			MergeResult updateKeyDiffUnset = new MergeResult();
+			updateKeyDiffUnset.setFilter(mergeResult.getFilter());
+			updateKeyDiffUnset.setOperation(MergeResult.Operation.UPDATE);
+			updateKeyDiffUnset.setUpdate(new Document("$unset", unset));
+			updateKeyDiffUnset.setUpdateOptions(new UpdateOptions().upsert(false));
+			return updateKeyDiffUnset;
+		}
+		return null;
 	}
 
 	private static MergeResult updateIntoArrayMergeIfNeed(MergeBundle mergeBundle, MergeTableProperties properties, MergeResult mergeResult, MergeFilter mergeFilter) {

--- a/connectors/mongodb-connector/src/test/java/io/tapdata/mongodb/util/MapDiffUtilTest.java
+++ b/connectors/mongodb-connector/src/test/java/io/tapdata/mongodb/util/MapDiffUtilTest.java
@@ -1,0 +1,228 @@
+package io.tapdata.mongodb.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for MapDiffUtil.compareAndFindMissingKeys method
+ */
+public class MapDiffUtilTest {
+
+    @Test
+    @DisplayName("Test empty Map scenarios")
+    public void testEmptyMaps() {
+        // Test when before is null
+        List<MapDiffUtil.KeyDiffInfo> result1 = MapDiffUtil.compareAndFindMissingKeys(null, createMap("key1", "value1"));
+        assertTrue(result1.isEmpty(), "Should return empty list when before is null");
+
+        // Test when before is empty Map
+        List<MapDiffUtil.KeyDiffInfo> result2 = MapDiffUtil.compareAndFindMissingKeys(new HashMap<>(), createMap("key1", "value1"));
+        assertTrue(result2.isEmpty(), "Should return empty list when before is empty Map");
+
+        // Test when after is null
+        Map<String, Object> before = createMap("key1", "value1");
+        List<MapDiffUtil.KeyDiffInfo> result3 = MapDiffUtil.compareAndFindMissingKeys(before, null);
+        assertEquals(1, result3.size(), "Should return all keys in before when after is null");
+        assertEquals("key1", result3.get(0).getKey());
+
+        // Test when after is empty Map
+        List<MapDiffUtil.KeyDiffInfo> result4 = MapDiffUtil.compareAndFindMissingKeys(before, new HashMap<>());
+        assertEquals(1, result4.size(), "Should return all keys in before when after is empty Map");
+        assertEquals("key1", result4.get(0).getKey());
+    }
+
+    @Test
+    @DisplayName("Test basic key differences")
+    public void testBasicKeyDifferences() {
+        Map<String, Object> before = new HashMap<>();
+        before.put("key1", "value1");
+        before.put("key2", "value2");
+        before.put("key3", "value3");
+
+        Map<String, Object> after = new HashMap<>();
+        after.put("key1", "value1");
+        after.put("key3", "value3_modified");
+
+        List<MapDiffUtil.KeyDiffInfo> result = MapDiffUtil.compareAndFindMissingKeys(before, after);
+
+        assertEquals(1, result.size(), "Should find 1 missing key");
+        assertEquals("key2", result.get(0).getKey());
+        assertEquals("key2", result.get(0).getFullPath());
+        assertNull(result.get(0).getPathTypes(), "Path types should be null");
+    }
+
+    @Test
+    @DisplayName("Test nested Map differences")
+    public void testNestedMapDifferences() {
+        Map<String, Object> before = new HashMap<>();
+        Map<String, Object> nestedBefore = new HashMap<>();
+        nestedBefore.put("nestedKey1", "nestedValue1");
+        nestedBefore.put("nestedKey2", "nestedValue2");
+        before.put("nested", nestedBefore);
+        before.put("topLevel", "topValue");
+
+        Map<String, Object> after = new HashMap<>();
+        Map<String, Object> nestedAfter = new HashMap<>();
+        nestedAfter.put("nestedKey1", "nestedValue1");
+        after.put("nested", nestedAfter);
+        // topLevel does not exist in after
+
+        List<MapDiffUtil.KeyDiffInfo> result = MapDiffUtil.compareAndFindMissingKeys(before, after);
+
+        assertEquals(2, result.size(), "Should find 2 missing keys");
+
+        // Verify result contains expected differences
+        Set<String> missingKeys = new HashSet<>();
+        Set<String> missingPaths = new HashSet<>();
+        for (MapDiffUtil.KeyDiffInfo diffInfo : result) {
+            missingKeys.add(diffInfo.getKey());
+            missingPaths.add(diffInfo.getFullPath());
+            assertNull(diffInfo.getPathTypes(), "Path types should be null");
+        }
+
+        assertTrue(missingKeys.contains("topLevel"), "Should contain topLevel");
+        assertTrue(missingKeys.contains("nestedKey2"), "Should contain nestedKey2");
+        assertTrue(missingPaths.contains("topLevel"), "Should contain topLevel path");
+        assertTrue(missingPaths.contains("nested.nestedKey2"), "Should contain nested.nestedKey2 path");
+    }
+
+    @Test
+    @DisplayName("Test deep nested Map differences")
+    public void testDeepNestedMapDifferences() {
+        Map<String, Object> before = new HashMap<>();
+        Map<String, Object> level1 = new HashMap<>();
+        Map<String, Object> level2 = new HashMap<>();
+        Map<String, Object> level3 = new HashMap<>();
+
+        level3.put("deepKey", "deepValue");
+        level2.put("level3", level3);
+        level1.put("level2", level2);
+        before.put("level1", level1);
+
+        Map<String, Object> after = new HashMap<>();
+        Map<String, Object> afterLevel1 = new HashMap<>();
+        Map<String, Object> afterLevel2 = new HashMap<>();
+        // level3 does not exist in after
+        afterLevel1.put("level2", afterLevel2);
+        after.put("level1", afterLevel1);
+
+        List<MapDiffUtil.KeyDiffInfo> result = MapDiffUtil.compareAndFindMissingKeys(before, after);
+
+        assertEquals(1, result.size(), "Should find 1 missing key");
+        assertEquals("level3", result.get(0).getKey());
+        assertEquals("level1.level2.level3", result.get(0).getFullPath());
+        assertNull(result.get(0).getPathTypes(), "Path types should be null");
+    }
+
+    @Test
+    @DisplayName("Test arrays are ignored")
+    public void testArraysAreIgnored() {
+        Map<String, Object> before = new HashMap<>();
+        before.put("arrayField", Arrays.asList("item1", "item2", "item3"));
+        before.put("mapField", createMap("mapKey", "mapValue"));
+
+        Map<String, Object> after = new HashMap<>();
+        after.put("arrayField", Arrays.asList("item1")); // Array content is different, but should be ignored
+        // mapField does not exist in after
+
+        List<MapDiffUtil.KeyDiffInfo> result = MapDiffUtil.compareAndFindMissingKeys(before, after);
+
+        assertEquals(1, result.size(), "Should only find 1 missing key (array differences ignored)");
+        assertEquals("mapField", result.get(0).getKey());
+        assertEquals("mapField", result.get(0).getFullPath());
+        assertNull(result.get(0).getPathTypes(), "Path types should be null");
+    }
+
+    @Test
+    @DisplayName("Test Map type mismatch")
+    public void testMapTypeMismatch() {
+        Map<String, Object> before = new HashMap<>();
+        Map<String, Object> nestedMap = new HashMap<>();
+        nestedMap.put("innerKey1", "innerValue1");
+        nestedMap.put("innerKey2", "innerValue2");
+        before.put("field", nestedMap);
+
+        Map<String, Object> after = new HashMap<>();
+        after.put("field", "stringValue"); // before is Map, after is String
+
+        List<MapDiffUtil.KeyDiffInfo> result = MapDiffUtil.compareAndFindMissingKeys(before, after);
+
+        assertEquals(2, result.size(), "Should find 2 missing keys");
+
+        Set<String> missingKeys = new HashSet<>();
+        Set<String> missingPaths = new HashSet<>();
+        for (MapDiffUtil.KeyDiffInfo diffInfo : result) {
+            missingKeys.add(diffInfo.getKey());
+            missingPaths.add(diffInfo.getFullPath());
+            assertNull(diffInfo.getPathTypes(), "Path types should be null");
+        }
+
+        assertTrue(missingKeys.contains("innerKey1"), "Should contain innerKey1");
+        assertTrue(missingKeys.contains("innerKey2"), "Should contain innerKey2");
+        assertTrue(missingPaths.contains("field.innerKey1"), "Should contain field.innerKey1 path");
+        assertTrue(missingPaths.contains("field.innerKey2"), "Should contain field.innerKey2 path");
+    }
+
+    @Test
+    @DisplayName("Test identical Maps")
+    public void testIdenticalMaps() {
+        Map<String, Object> map1 = new HashMap<>();
+        map1.put("key1", "value1");
+        map1.put("key2", createMap("nestedKey", "nestedValue"));
+
+        Map<String, Object> map2 = new HashMap<>();
+        map2.put("key1", "value1");
+        map2.put("key2", createMap("nestedKey", "nestedValue"));
+
+        List<MapDiffUtil.KeyDiffInfo> result = MapDiffUtil.compareAndFindMissingKeys(map1, map2);
+
+        assertTrue(result.isEmpty(), "Identical Maps should have no differences");
+    }
+
+    @Test
+    @DisplayName("Test complex mixed scenario")
+    public void testComplexMixedScenario() {
+        Map<String, Object> before = new HashMap<>();
+
+        // Add various types of data
+        before.put("simpleString", "value");
+        before.put("simpleNumber", 123);
+        before.put("arrayField", Arrays.asList("a", "b", "c"));
+
+        Map<String, Object> nestedMap = new HashMap<>();
+        nestedMap.put("nestedString", "nestedValue");
+        nestedMap.put("nestedArray", Arrays.asList(1, 2, 3));
+        nestedMap.put("deepNested", createMap("deepKey", "deepValue"));
+        before.put("nestedMap", nestedMap);
+
+        Map<String, Object> after = new HashMap<>();
+        after.put("simpleString", "value");
+        after.put("simpleNumber", 456); // Value is different but key exists
+        after.put("arrayField", Arrays.asList("a")); // Array content is different, should be ignored
+
+        Map<String, Object> afterNestedMap = new HashMap<>();
+        afterNestedMap.put("nestedString", "nestedValue");
+        afterNestedMap.put("nestedArray", Arrays.asList(1, 2)); // Array differences should be ignored
+        // deepNested does not exist in after
+        after.put("nestedMap", afterNestedMap);
+
+        List<MapDiffUtil.KeyDiffInfo> result = MapDiffUtil.compareAndFindMissingKeys(before, after);
+
+        assertEquals(1, result.size(), "Should only find 1 missing key");
+        assertEquals("deepNested", result.get(0).getKey());
+        assertEquals("nestedMap.deepNested", result.get(0).getFullPath());
+        assertNull(result.get(0).getPathTypes(), "Path types should be null");
+    }
+
+    /**
+     * Helper method: Create a simple Map
+     */
+    private Map<String, Object> createMap(String key, Object value) {
+        Map<String, Object> map = new HashMap<>();
+        map.put(key, value);
+        return map;
+    }
+}

--- a/connectors/mongodb-connector/src/test/java/io/tapdata/mongodb/writer/MongodbMergeOperateTest.java
+++ b/connectors/mongodb-connector/src/test/java/io/tapdata/mongodb/writer/MongodbMergeOperateTest.java
@@ -194,7 +194,8 @@ class MongodbMergeOperateTest {
 					null,
 					null,
 					mergeFilter,
-					1
+					1,
+					null
 			);
 			assertEquals(3, mergeResults.size());
 		}

--- a/connectors/mongodb-connector/src/test/java/io/tapdata/mongodb/writer/MongodbWriterTest.java
+++ b/connectors/mongodb-connector/src/test/java/io/tapdata/mongodb/writer/MongodbWriterTest.java
@@ -48,6 +48,9 @@ class MongodbWriterTest {
 
 	@BeforeEach
 	void setUp() {
+		// 设置app_type系统属性，避免AppType初始化失败
+		System.setProperty("app_type", "DAAS");
+
 		globalStateMap = new KVMap<Object>() {
 			Map<String, Object> map = new HashMap<>();
 
@@ -201,42 +204,358 @@ class MongodbWriterTest {
 	@Nested
 	@DisplayName("Method wrapUnset test")
 	class wrapUnsetTest {
+
 		@Test
-		@DisplayName("test insert event")
-		void test1() {
-			TapInsertRecordEvent tapInsertRecordEvent = TapInsertRecordEvent.create()
-					.after(new Document("id", 1).append("f1", 1))
-					.removedFields(new ArrayList<String>() {{
-						add("f2");
-					}});
-			Document document = mongodbWriter.wrapUnset(tapInsertRecordEvent);
-			assertEquals(1, document.size());
-			assertInstanceOf(Boolean.class, document.get("f2"));
-			assertTrue((Boolean) document.get("f2"));
+		@DisplayName("test TapInsertRecordEvent with removedFields and after")
+		void testInsertEventWithRemovedFields() {
+			// 准备测试数据
+			Map<String, Object> after = new HashMap<>();
+			after.put("id", 1);
+			after.put("name", "test");
+			after.put("address", "beijing");
+
+			List<String> removedFields = new ArrayList<>();
+			removedFields.add("age");
+			removedFields.add("email");
+
+			TapInsertRecordEvent insertEvent = TapInsertRecordEvent.create()
+					.after(after)
+					.removedFields(removedFields);
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(insertEvent);
+
+			// 验证结果
+			assertNotNull(result);
+			assertEquals(2, result.size());
+			assertTrue(result.containsKey("age"));
+			assertTrue(result.containsKey("email"));
+			assertEquals(true, result.get("age"));
+			assertEquals(true, result.get("email"));
 		}
 
 		@Test
-		@DisplayName("test update event")
-		void test2() {
-			TapUpdateRecordEvent tapUpdateRecordEvent = TapUpdateRecordEvent.create()
-					.before(new Document("id", 1).append("f1", 1))
-					.after(new Document("id", 1).append("f1", 2))
-					.removedFields(new ArrayList<String>() {{
-						add("f2");
-					}});
-			Document document = mongodbWriter.wrapUnset(tapUpdateRecordEvent);
-			assertEquals(1, document.size());
-			assertInstanceOf(Boolean.class, document.get("f2"));
-			assertTrue((Boolean) document.get("f2"));
+		@DisplayName("test TapUpdateRecordEvent with removedFields and after")
+		void testUpdateEventWithRemovedFields() {
+			// 准备测试数据
+			Map<String, Object> after = new HashMap<>();
+			after.put("id", 1);
+			after.put("name", "updated");
+
+			List<String> removedFields = new ArrayList<>();
+			removedFields.add("age");
+			removedFields.add("phone");
+
+			TapUpdateRecordEvent updateEvent = TapUpdateRecordEvent.create()
+					.after(after)
+					.removedFields(removedFields);
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(updateEvent);
+
+			// 验证结果
+			assertNotNull(result);
+			assertEquals(2, result.size());
+			assertTrue(result.containsKey("age"));
+			assertTrue(result.containsKey("phone"));
 		}
 
 		@Test
-		@DisplayName("test delete event")
-		void test3() {
-			TapDeleteRecordEvent tapDeleteRecordEvent = TapDeleteRecordEvent.create()
-					.before(new Document("id", 1));
-			Document document = mongodbWriter.wrapUnset(tapDeleteRecordEvent);
-			assertNull(document);
+		@DisplayName("test with null removedFields")
+		void testNullRemovedFields() {
+			// 准备测试数据
+			Map<String, Object> after = new HashMap<>();
+			after.put("id", 1);
+			after.put("name", "test");
+
+			TapInsertRecordEvent insertEvent = TapInsertRecordEvent.create()
+					.after(after)
+					.removedFields(null);
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(insertEvent);
+
+			// 验证结果
+			assertNull(result);
+		}
+
+		@Test
+		@DisplayName("test with empty removedFields")
+		void testEmptyRemovedFields() {
+			// 准备测试数据
+			Map<String, Object> after = new HashMap<>();
+			after.put("id", 1);
+			after.put("name", "test");
+
+			TapInsertRecordEvent insertEvent = TapInsertRecordEvent.create()
+					.after(after)
+					.removedFields(new ArrayList<>());
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(insertEvent);
+
+			// 验证结果
+			assertNull(result);
+		}
+
+		@Test
+		@DisplayName("test with null after")
+		void testNullAfter() {
+			// 准备测试数据
+			List<String> removedFields = new ArrayList<>();
+			removedFields.add("age");
+			removedFields.add("email");
+
+			TapInsertRecordEvent insertEvent = TapInsertRecordEvent.create()
+					.after(null)
+					.removedFields(removedFields);
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(insertEvent);
+
+			// 验证结果
+			assertNull(result);
+		}
+
+		@Test
+		@DisplayName("test with empty after")
+		void testEmptyAfter() {
+			// 准备测试数据
+			List<String> removedFields = new ArrayList<>();
+			removedFields.add("age");
+			removedFields.add("email");
+
+			TapInsertRecordEvent insertEvent = TapInsertRecordEvent.create()
+					.after(new HashMap<>())
+					.removedFields(removedFields);
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(insertEvent);
+
+			// 验证结果
+			assertNull(result);
+		}
+
+		@Test
+		@DisplayName("test hierarchical fields filtering - parent field exists")
+		void testHierarchicalFieldsFilteringParentExists() {
+			// 准备测试数据
+			Map<String, Object> after = new HashMap<>();
+			after.put("id", 1);
+			after.put("name", "test");
+
+			// removedFields包含层级字段，应该只保留最高层级的字段
+			List<String> removedFields = new ArrayList<>();
+			removedFields.add("user");
+			removedFields.add("user.name");
+			removedFields.add("user.age");
+			removedFields.add("user.profile.email");
+
+			TapInsertRecordEvent insertEvent = TapInsertRecordEvent.create()
+					.after(after)
+					.removedFields(removedFields);
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(insertEvent);
+
+			// 验证结果 - 应该只包含最高层级的字段 "user"
+			assertNotNull(result);
+			assertEquals(1, result.size());
+			assertTrue(result.containsKey("user"));
+			assertFalse(result.containsKey("user.name"));
+			assertFalse(result.containsKey("user.age"));
+			assertFalse(result.containsKey("user.profile.email"));
+		}
+
+		@Test
+		@DisplayName("test hierarchical fields filtering - no parent field")
+		void testHierarchicalFieldsFilteringNoParent() {
+			// 准备测试数据
+			Map<String, Object> after = new HashMap<>();
+			after.put("id", 1);
+			after.put("name", "test");
+
+			// removedFields包含同级字段
+			List<String> removedFields = new ArrayList<>();
+			removedFields.add("user.name");
+			removedFields.add("user.age");
+			removedFields.add("profile.email");
+
+			TapInsertRecordEvent insertEvent = TapInsertRecordEvent.create()
+					.after(after)
+					.removedFields(removedFields);
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(insertEvent);
+
+			// 验证结果 - 应该包含所有字段，因为没有父字段覆盖
+			assertNotNull(result);
+			assertEquals(3, result.size());
+			assertTrue(result.containsKey("user.name"));
+			assertTrue(result.containsKey("user.age"));
+			assertTrue(result.containsKey("profile.email"));
+		}
+
+		@Test
+		@DisplayName("test field exists in after - should be excluded from unset")
+		void testFieldExistsInAfter() {
+			// 准备测试数据
+			Map<String, Object> after = new HashMap<>();
+			after.put("id", 1);
+			after.put("name", "test");
+			after.put("age", 25); // age字段在after中存在
+
+			List<String> removedFields = new ArrayList<>();
+			removedFields.add("age");
+			removedFields.add("email");
+			removedFields.add("phone");
+
+			TapInsertRecordEvent insertEvent = TapInsertRecordEvent.create()
+					.after(after)
+					.removedFields(removedFields);
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(insertEvent);
+
+			// 验证结果 - age字段在after中存在，不应该被unset
+			assertNotNull(result);
+			assertEquals(2, result.size());
+			assertFalse(result.containsKey("age")); // age不应该在unset中
+			assertTrue(result.containsKey("email"));
+			assertTrue(result.containsKey("phone"));
+		}
+
+		@Test
+		@DisplayName("test parent field exists in after - child field should be excluded")
+		void testParentFieldExistsInAfter() {
+			// 准备测试数据
+			Map<String, Object> after = new HashMap<>();
+			after.put("id", 1);
+			after.put("user", new HashMap<String, Object>() {{
+				put("name", "test");
+				put("age", 25);
+			}});
+
+			List<String> removedFields = new ArrayList<>();
+			removedFields.add("user.email");
+			removedFields.add("user.phone");
+			removedFields.add("profile.address");
+
+			TapInsertRecordEvent insertEvent = TapInsertRecordEvent.create()
+					.after(after)
+					.removedFields(removedFields);
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(insertEvent);
+
+			// 验证结果 - user字段在after中存在，user.email和user.phone不应该被unset
+			assertNotNull(result);
+			assertEquals(1, result.size());
+			assertFalse(result.containsKey("user.email")); // user字段存在，子字段不应该unset
+			assertFalse(result.containsKey("user.phone"));
+			assertTrue(result.containsKey("profile.address")); // profile字段不存在，可以unset
+		}
+
+		@Test
+		@DisplayName("test complex hierarchical scenario")
+		void testComplexHierarchicalScenario() {
+			// 准备测试数据
+			Map<String, Object> after = new HashMap<>();
+			after.put("id", 1);
+			after.put("user", new HashMap<String, Object>() {{
+				put("name", "test");
+			}});
+			after.put("profile.city", "beijing"); // 注意这是一个带点的key，不是嵌套对象
+
+			List<String> removedFields = new ArrayList<>();
+			removedFields.add("user.age");           // user存在，user.age不应该unset
+			removedFields.add("user.email");         // user存在，user.email不应该unset
+			removedFields.add("profile.address");    // profile.city存在，但profile.address可以unset（不是父子关系）
+			removedFields.add("profile.city.street"); // profile.city存在，profile.city.street不应该unset
+			removedFields.add("contact.phone");      // contact不存在，可以unset
+			removedFields.add("contact");             // 应该被过滤掉，因为contact.phone是子字段
+
+			TapInsertRecordEvent insertEvent = TapInsertRecordEvent.create()
+					.after(after)
+					.removedFields(removedFields);
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(insertEvent);
+
+			// 验证结果
+			assertNotNull(result);
+			// 应该只包含 profile.address 和 contact（因为层级过滤会保留contact而不是contact.phone）
+			assertEquals(2, result.size());
+			assertFalse(result.containsKey("user.age"));
+			assertFalse(result.containsKey("user.email"));
+			assertTrue(result.containsKey("profile.address"));
+			assertFalse(result.containsKey("profile.city.street"));
+			assertTrue(result.containsKey("contact")); // 层级过滤后保留最高级
+			assertFalse(result.containsKey("contact.phone"));
+		}
+
+		@Test
+		@DisplayName("test TapDeleteRecordEvent - should return null")
+		void testDeleteEvent() {
+			// 准备测试数据
+			Map<String, Object> before = new HashMap<>();
+			before.put("id", 1);
+			before.put("name", "test");
+
+			TapDeleteRecordEvent deleteEvent = TapDeleteRecordEvent.create()
+					.before(before);
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(deleteEvent);
+
+			// 验证结果 - delete事件不支持，应该返回null
+			assertNull(result);
+		}
+
+		@Test
+		@DisplayName("test unsupported event type")
+		void testUnsupportedEventType() {
+			// 创建一个不支持的事件类型
+			TapRecordEvent unsupportedEvent = new TapRecordEvent(999) {
+				@Override
+				public Map<String, Object> getFilter(Collection<String> primaryKeys) {
+					return null;
+				}
+			};
+
+			// 执行测试
+			Document result = mongodbWriter.wrapUnset(unsupportedEvent);
+
+			// 验证结果
+			assertNull(result);
+		}
+
+		@Test
+		@DisplayName("test single field scenarios")
+		void testSingleFieldScenarios() {
+			// 测试单个字段的各种情况
+			Map<String, Object> after = new HashMap<>();
+			after.put("id", 1);
+
+			// 情况1：单个字段不在after中
+			List<String> removedFields1 = new ArrayList<>();
+			removedFields1.add("name");
+			TapInsertRecordEvent event1 = TapInsertRecordEvent.create()
+					.after(after)
+					.removedFields(removedFields1);
+			Document result1 = mongodbWriter.wrapUnset(event1);
+			assertNotNull(result1);
+			assertEquals(1, result1.size());
+			assertTrue(result1.containsKey("name"));
+
+			// 情况2：单个字段在after中
+			after.put("name", "test");
+			TapInsertRecordEvent event2 = TapInsertRecordEvent.create()
+					.after(after)
+					.removedFields(removedFields1);
+			Document result2 = mongodbWriter.wrapUnset(event2);
+			assertNotNull(result2);
+			assertEquals(0, result2.size()); // name在after中，不应该unset
 		}
 	}
 
@@ -265,9 +584,14 @@ class MongodbWriterTest {
 			TapInsertRecordEvent tapInsertRecordEvent = TapInsertRecordEvent.create()
 					.after(new Document("id", 1).append("f1", 1))
 					.removedFields(removeFields);
-			WriteModel<Document> writeModel = mongodbWriter.normalWriteMode(new AtomicLong(), new AtomicLong(), new AtomicLong(), new UpdateOptions().upsert(true), tapTable, pks, tapInsertRecordEvent);
-			assertInstanceOf(UpdateManyModel.class, writeModel);
-			Document update = (Document) ((UpdateManyModel<Document>) writeModel).getUpdate();
+			List<WriteModel<Document>> writeModels = mongodbWriter.normalWriteMode(new AtomicLong(), new AtomicLong(), new AtomicLong(), new UpdateOptions().upsert(true), tapTable, pks, tapInsertRecordEvent);
+			assertNotNull(writeModels);
+			assertEquals(2, writeModels.size());
+			assertInstanceOf(UpdateManyModel.class, writeModels.get(0));
+			Document update = (Document) ((UpdateManyModel<Document>) (writeModels.get(0))).getUpdate();
+			assertTrue(update.containsKey("$set"));
+			assertInstanceOf(UpdateManyModel.class, writeModels.get(1));
+			update = (Document) ((UpdateManyModel<Document>) (writeModels.get(1))).getUpdate();
 			assertTrue(update.containsKey("$unset"));
 		}
 
@@ -282,9 +606,14 @@ class MongodbWriterTest {
 			TapInsertRecordEvent tapInsertRecordEvent = TapInsertRecordEvent.create()
 					.after(new Document("id", 1).append("f1", 1))
 					.removedFields(removeFields);
-			WriteModel<Document> writeModel = mongodbWriter.normalWriteMode(new AtomicLong(), new AtomicLong(), new AtomicLong(), new UpdateOptions().upsert(true), tapTable, pks, tapInsertRecordEvent);
-			assertInstanceOf(UpdateManyModel.class, writeModel);
-			Document update = (Document) ((UpdateManyModel<Document>) writeModel).getUpdate();
+			List<WriteModel<Document>> writeModels = mongodbWriter.normalWriteMode(new AtomicLong(), new AtomicLong(), new AtomicLong(), new UpdateOptions().upsert(true), tapTable, pks, tapInsertRecordEvent);
+			assertNotNull(writeModels);
+			assertEquals(2, writeModels.size());
+			assertInstanceOf(UpdateManyModel.class, writeModels.get(0));
+			Document update = (Document) ((UpdateManyModel<Document>) (writeModels.get(0))).getUpdate();
+			assertTrue(update.containsKey("$set"));
+			assertInstanceOf(UpdateManyModel.class, writeModels.get(1));
+			update = (Document) ((UpdateManyModel<Document>) (writeModels.get(1))).getUpdate();
 			assertTrue(update.containsKey("$unset"));
 		}
 
@@ -299,9 +628,14 @@ class MongodbWriterTest {
 					.before(new Document("id", 1).append("f1", 1))
 					.after(new Document("id", 1).append("f1", 2))
 					.removedFields(removeFields);
-			WriteModel<Document> writeModel = mongodbWriter.normalWriteMode(new AtomicLong(), new AtomicLong(), new AtomicLong(), new UpdateOptions().upsert(true), tapTable, pks, tapUpdateRecordEvent);
-			assertInstanceOf(UpdateManyModel.class, writeModel);
-			Document update = (Document) ((UpdateManyModel<Document>) writeModel).getUpdate();
+			List<WriteModel<Document>> writeModels = mongodbWriter.normalWriteMode(new AtomicLong(), new AtomicLong(), new AtomicLong(), new UpdateOptions().upsert(true), tapTable, pks, tapUpdateRecordEvent);
+			assertNotNull(writeModels);
+			assertEquals(2, writeModels.size());
+			assertInstanceOf(UpdateManyModel.class, writeModels.get(0));
+			Document update = (Document) ((UpdateManyModel<Document>) (writeModels.get(0))).getUpdate();
+			assertTrue(update.containsKey("$set"));
+			assertInstanceOf(UpdateManyModel.class, writeModels.get(1));
+			update = (Document) ((UpdateManyModel<Document>) (writeModels.get(1))).getUpdate();
 			assertTrue(update.containsKey("$unset"));
 		}
 	}


### PR DESCRIPTION
1. 优化unset逻辑，避免父子段与子字段同时存在，执行导致报错；
2. 优化写入逻辑，将set和unset拆分为两个命令，避免set和unset字段冲突错误；
3. 主从合并写入，新增对于更新事件，比对before和after，补充unset已被删除的字段