### PR TITLE
feat(spec): declare cyntex.modes on 18 connectors

### DIFF
--- a/connectors-javascript/ali1688-connector/src/main/resources/spec.json
+++ b/connectors-javascript/ali1688-connector/src/main/resources/spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["api"]
+  },
   "properties": {
     "name": "Alibaba 1688",
     "realName": "Alibaba 1688",

--- a/connectors-javascript/github-connector/src/main/resources/spec.json
+++ b/connectors-javascript/github-connector/src/main/resources/spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["api"]
+  },
   "properties": {
     "name": "GitHub",
     "realName": "GitHub",

--- a/connectors-javascript/hubspot-connector/src/main/resources/spec.json
+++ b/connectors-javascript/hubspot-connector/src/main/resources/spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["api"]
+  },
   "properties": {
     "name": "HubSpot",
     "realName": "HubSpot",

--- a/connectors-javascript/lark-approval-connector/src/main/resources/spec.json
+++ b/connectors-javascript/lark-approval-connector/src/main/resources/spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["api"]
+  },
   "properties": {
     "name": "Lark Approval",
     "realName": "Lark Approval",

--- a/connectors-javascript/lark-bitable-connector/src/main/resources/spec.json
+++ b/connectors-javascript/lark-bitable-connector/src/main/resources/spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["api"]
+  },
   "properties": {
     "name": "Feishu-Bitable",
     "realName": "Lark Bitable",

--- a/connectors-javascript/lark-doc-connector/src/main/resources/spec.json
+++ b/connectors-javascript/lark-doc-connector/src/main/resources/spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["api"]
+  },
   "properties": {
     "name": "Lark Doc",
     "realName": "Lark Doc",

--- a/connectors-javascript/metabase-connector/src/main/resources/spec.json
+++ b/connectors-javascript/metabase-connector/src/main/resources/spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["api"]
+  },
   "properties": {
     "name": "Metabase",
     "realName": "Metabase",

--- a/connectors-javascript/salesforce-connector/src/main/resources/spec.json
+++ b/connectors-javascript/salesforce-connector/src/main/resources/spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["api"]
+  },
   "properties": {
     "name": "Salesforce",
     "realName": "Salesforce",

--- a/connectors-javascript/shein-connector/src/main/resources/spec.json
+++ b/connectors-javascript/shein-connector/src/main/resources/spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["api"]
+  },
   "properties": {
     "name": "Shein",
     "realName": "Shein",

--- a/connectors-javascript/temu-connector/src/main/resources/spec.json
+++ b/connectors-javascript/temu-connector/src/main/resources/spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["api"]
+  },
   "properties": {
     "name": "Temu",
     "icon": "icon/temu.png",

--- a/connectors-javascript/zoho-crm-connector/src/main/resources/spec.json
+++ b/connectors-javascript/zoho-crm-connector/src/main/resources/spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["api"]
+  },
   "properties": {
     "name": "Zoho-CRM",
     "realName": "Zoho CRM",

--- a/connectors/activemq-connector/src/main/resources/spec_activemq.json
+++ b/connectors/activemq-connector/src/main/resources/spec_activemq.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["stream"]
+  },
   "properties": {
     "name": "ActiveMQ",
     "realName": "Apache ActiveMQ",

--- a/connectors/kafka-connector/src/main/resources/spec_kafka.json
+++ b/connectors/kafka-connector/src/main/resources/spec_kafka.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["stream"]
+  },
   "properties": {
     "name": "Kafka",
     "realName": "Apache Kafka(Deprecated)",

--- a/connectors/kafka-enhanced-connector/src/main/resources/spec_kafka_enhanced.json
+++ b/connectors/kafka-enhanced-connector/src/main/resources/spec_kafka_enhanced.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["stream"]
+  },
   "properties": {
     "name": "Kafka-Enhanced",
     "realName": "Apache Kafka(Confluent Compatible)",

--- a/connectors/rabbitmq-connector/src/main/resources/spec_rabbitmq.json
+++ b/connectors/rabbitmq-connector/src/main/resources/spec_rabbitmq.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["stream"]
+  },
   "properties": {
     "name": "RabbitMQ",
     "realName": "RabbitMQ",

--- a/connectors/rocketmq-connector/src/main/resources/spec_rocketmq.json
+++ b/connectors/rocketmq-connector/src/main/resources/spec_rocketmq.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["stream"]
+  },
   "properties": {
     "name": "RocketMQ",
     "realName": "Apache RocketMQ",

--- a/connectors/selectdb-connector/src/main/resources/spec_selectdb.json
+++ b/connectors/selectdb-connector/src/main/resources/spec_selectdb.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["snapshot"]
+  },
   "properties": {
     "name": "SelectDB",
     "realName": "SelectDB",

--- a/connectors/yashandb-connector/src/main/resources/yashandb-spec.json
+++ b/connectors/yashandb-connector/src/main/resources/yashandb-spec.json
@@ -1,4 +1,7 @@
 {
+  "cyntex": {
+    "modes": ["snapshot"]
+  },
   "properties": {
     "name": "YashanDB",
     "realName": "YashanDB",


### PR DESCRIPTION
Add the additive, optional `cyntex` namespace carrying source modes that Cyntex's offline catalog cannot derive from registerCapabilities(). Tapdata/PDK never read this namespace.

  api (11):     github, ali1688, lark-bitable, hubspot, lark-approval,
                lark-doc, metabase, salesforce, shein, temu, zoho-crm
  snapshot (2): selectdb, yashandb (queryByFilter + batchCount read path,
                no batchRead so snapshot does not derive)
  stream (5):   activemq, kafka, kafka-enhanced, rabbitmq, rocketmq
                (corrects the streamRead -> cdc default for message queues)