### PR TITLE
fix: TAP-12095 mssql target multithread mode fails with date conversi…

### DIFF
--- a/connectors-common/sql-core/src/main/java/io/tapdata/common/dml/NormalWriteRecorder.java
+++ b/connectors-common/sql-core/src/main/java/io/tapdata/common/dml/NormalWriteRecorder.java
@@ -545,7 +545,8 @@ public abstract class NormalWriteRecorder {
         return value;
     }
 
-    private static final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSSSS");
+    private static final ThreadLocal<DateFormat> dateFormat = ThreadLocal.withInitial(
+            () -> new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSSSS"));
     private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
 
     protected String object2String(Object obj) {
@@ -557,7 +558,7 @@ public abstract class NormalWriteRecorder {
         } else if (obj instanceof Number) {
             result = obj.toString();
         } else if (obj instanceof Date) {
-            result = "'" + dateFormat.format(obj) + "'";
+            result = "'" + dateFormat.get().format(obj) + "'";
         } else if (obj instanceof Instant) {
             result = "'" + LocalDateTime.ofInstant((Instant) obj, ZoneId.of("GMT")).format(dateTimeFormatter) + "'";
         } else if (obj instanceof byte[]) {

--- a/connectors-common/sql-core/src/test/java/io/tapdata/common/dml/NormalWriteRecorderTest.java
+++ b/connectors-common/sql-core/src/test/java/io/tapdata/common/dml/NormalWriteRecorderTest.java
@@ -11,9 +11,17 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 import static io.tapdata.entity.simplify.TapSimplify.entry;
 import static io.tapdata.entity.simplify.TapSimplify.map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -72,6 +80,60 @@ public class NormalWriteRecorderTest {
             recorder.addUpdateBatch(after, before, new WriteListResult<>());
             verify(recorder, times(0)).insertUpdate(any(), any(), any());
             verify(recorder, times(0)).justUpdate(any(), any(), any());
+        }
+    }
+
+    @Nested
+    class Object2StringTest {
+
+        @Test
+        void testConcurrentDateFormat() throws Exception {
+            NormalWriteRecorder recorder = mock(NormalWriteRecorder.class);
+            when(recorder.object2String(any())).thenCallRealMethod();
+            java.sql.Date date = java.sql.Date.valueOf("2026-06-23");
+            String expected = "'2026-06-23 00:00:00.000000'";
+            Pattern expectedPattern = Pattern.compile("'\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{6}'");
+            int threads = 16;
+            int iterationsPerThread = 2000;
+            ExecutorService pool = Executors.newFixedThreadPool(threads);
+            CountDownLatch ready = new CountDownLatch(threads);
+            CountDownLatch start = new CountDownLatch(1);
+            AtomicInteger malformed = new AtomicInteger();
+            AtomicInteger mismatched = new AtomicInteger();
+            AtomicInteger errors = new AtomicInteger();
+            try {
+                for (int t = 0; t < threads; t++) {
+                    pool.submit(() -> {
+                        ready.countDown();
+                        try {
+                            start.await();
+                            for (int i = 0; i < iterationsPerThread; i++) {
+                                try {
+                                    String out = recorder.object2String(date);
+                                    if (!expectedPattern.matcher(out).matches()) {
+                                        malformed.incrementAndGet();
+                                    } else if (!expected.equals(out)) {
+                                        mismatched.incrementAndGet();
+                                    }
+                                } catch (Throwable t1) {
+                                    errors.incrementAndGet();
+                                }
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    });
+                }
+                ready.await();
+                start.countDown();
+                pool.shutdown();
+                assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS));
+            } finally {
+                pool.shutdownNow();
+            }
+            assertEquals(0, errors.get(), "object2String threw under concurrency");
+            assertEquals(0, malformed.get(), "object2String produced malformed date strings under concurrency");
+            assertEquals(0, mismatched.get(), "object2String produced unexpected date strings under concurrency");
         }
     }
 }


### PR DESCRIPTION
…on error when "preserve original table structure and data" is enabled